### PR TITLE
Extended blog structure

### DIFF
--- a/src/app/pages/pages/[slug].page.ts
+++ b/src/app/pages/pages/[slug].page.ts
@@ -1,0 +1,34 @@
+<script lang="ts">
+import { Component } from '@angular/core';
+import { injectContent, MarkdownComponent } from '@analogjs/content';
+import { AsyncPipe, NgIf } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+interface PageAttributes {
+  title: string;
+  slug: string;
+  description: string;
+  coverImage?: string;
+}
+
+@Component({
+  selector: 'app-page-detail',
+  standalone: true,
+  imports: [MarkdownComponent, AsyncPipe, NgIf, RouterLink],
+  template: `
+    <ng-container *ngIf="page$ | async as page">
+      <a routerLink="/pages">\u2190 All pages</a>
+      <h1>{{ page.attributes.title }}</h1>
+      <p>{{ page.attributes.description }}</p>
+      <img *ngIf="page.attributes.coverImage" [src]="page.attributes.coverImage" [alt]="page.attributes.title + ' cover image'" />
+      <analog-markdown [content]="page.content"></analog-markdown>
+    </ng-container>
+  `,
+})
+export default class PageDetailComponent {
+  protected page$ = injectContent<PageAttributes>({
+    param: 'slug',
+    subdirectory: 'pages',
+  });
+}
+</script>

--- a/src/app/pages/pages/index.page.ts
+++ b/src/app/pages/pages/index.page.ts
@@ -1,0 +1,35 @@
+<script lang="ts">
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { injectContentFiles } from '@analogjs/content';
+import { AsyncPipe, NgFor } from '@angular/common';
+
+interface PageAttributes {
+  title: string;
+  slug: string;
+  description: string;
+  coverImage?: string;
+}
+
+@Component({
+  selector: 'app-pages-index',
+  standalone: true,
+  imports: [RouterLink, NgFor, AsyncPipe],
+  template: `
+    <h1>Pages</h1>
+    <div *ngIf="pages$ | async as pages">
+      <article *ngFor="let page of pages">
+        <a [routerLink]="['/pages', page.attributes.slug]" class="no-underline">
+          <img *ngIf="page.attributes.coverImage" [src]="page.attributes.coverImage" [alt]="page.attributes.title + ' cover image'" />
+          <h2>{{ page.attributes.title }}</h2>
+          <p>{{ page.attributes.description }}</p>
+        </a>
+      </article>
+    </div>
+  `,
+})
+export default class PagesIndexPageComponent {
+  protected pages$ = injectContentFiles<PageAttributes>()
+    .filter((page) => page.slug.startsWith('/src/content/pages/'));
+}
+</script>

--- a/src/app/pages/projects/[slug].page.ts
+++ b/src/app/pages/projects/[slug].page.ts
@@ -1,0 +1,39 @@
+// src/app/pages/projects/[slug].page.ts
+import { injectContent, MarkdownComponent } from '@analogjs/content';
+import { AsyncPipe, NgIf } from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+export interface ProjectAttributes {
+  title: string;
+  slug: string;
+  description: string;
+  coverImage: string;
+}
+
+@Component({
+  standalone: true,
+  imports: [MarkdownComponent, AsyncPipe, NgIf, RouterLink],
+  template: `
+    <ng-container *ngIf="project$ | async as project">
+      <article class="flex flex-col">
+        <a routerLink="/projects" class="btn items-center mb-8 w-64 flex flex-row">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+          </svg>
+          <span>Back to Projects</span>
+        </a>
+        <h1 class="text-4xl font-bold mb-4">{{ project.attributes.title }}</h1>
+        <p class="text-lg mb-4">{{ project.attributes.description }}</p>
+        <img class="object-cover rounded-lg mb-6" [src]="project.attributes.coverImage" [alt]="project.attributes.title" />
+        <analog-markdown [content]="project.content"></analog-markdown>
+      </article>
+    </ng-container>
+  `,
+})
+export default class ProjectPage {
+  readonly project$ = injectContent<ProjectAttributes>({
+    param: 'slug',
+    subdirectory: 'projects',
+  });
+}

--- a/src/app/pages/projects/index.page.ts
+++ b/src/app/pages/projects/index.page.ts
@@ -1,0 +1,36 @@
+// src/app/pages/projects/index.page.ts
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { injectContentFiles } from '@analogjs/content';
+import { NgFor } from '@angular/common';
+
+export interface ProjectAttributes {
+  title: string;
+  slug: string;
+  description: string;
+  coverImage: string;
+}
+
+@Component({
+  standalone: true,
+  imports: [RouterLink, NgFor],
+  template: `
+    <section class="flex flex-col items-center">
+      <h1 class="font-bold text-5xl py-8">Projects</h1>
+      <div class="mt-8 border-t border-gray-200 flex gap-4 flex-wrap pt-10 w-full">
+        <article *ngFor="let project of projects" class="card shadow-xl p-4 md:w-1/3 w-full">
+          <a [routerLink]="['/projects', project.slug]" class="block hover:underline">
+            <h2 class="card-title">{{ project.attributes.title }}</h2>
+          </a>
+          <p class="mt-2">{{ project.attributes.description }}</p>
+          <img class="object-cover mt-4 w-full rounded-lg" [src]="project.attributes.coverImage" [alt]="project.attributes.title">
+        </article>
+      </div>
+    </section>
+  `,
+})
+export default class ProjectsIndexPage {
+  readonly projects = injectContentFiles<ProjectAttributes>((contentFile) =>
+    contentFile.filename.includes('/src/content/projects/')
+  );
+}

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -1,0 +1,10 @@
+---
+title: About
+slug: about
+description: Learn more about this blog
+coverImage: https://via.placeholder.com/800x400.png?text=About+Page
+---
+
+## About
+
+Welcome to the about page of this blog. You can customize this content by editing the `about.md` file in the `src/content/pages` directory. This area is powered by AnalogJS content routes, so you can add Markdown, headings, and more.

--- a/src/content/pages/contact.md
+++ b/src/content/pages/contact.md
@@ -1,0 +1,10 @@
+---
+title: Contact
+slug: contact
+description: Get in touch with us
+coverImage: https://via.placeholder.com/800x400.png?text=Contact+Page
+---
+
+## Contact
+
+If you'd like to get in touch, feel free to send an email to [your@example.com](mailto:your@example.com) or reach out via social media.

--- a/src/content/projects/sample-project.md
+++ b/src/content/projects/sample-project.md
@@ -1,0 +1,10 @@
+---
+title: Sample Project
+slug: sample-project
+description: A sample project description
+coverImage: https://via.placeholder.com/800x400.png?text=Sample+Project
+---
+
+## Sample Project
+
+This is a sample project page using AnalogJS content. Replace this text with details about your project. You can include code blocks, images, and more to showcase your work.


### PR DESCRIPTION
This PR sets up an extended AnalogJS blog structure for dynamic and static pages.

- Adds `src/content/pages` and `src/content/projects` directories with sample markdown content, including `about.md`, `contact.md` and a sample project (`sample-project.md`).
- Introduces dynamic routes in `src/app/pages/projects` and `src/app/pages/pages` to list and display markdown-driven pages similar to blog posts.
  - `projects/index.page.ts` lists all projects from `/src/content/projects` and `projects/[slug].page.ts` shows individual projects.
  - `pages/index.page.ts` lists all pages from `/src/content/pages` and `pages/[slug].page.ts` renders individual page content.

With this structure you can create new posts, pages or projects by adding markdown files under `src/content/blog`, `src/content/pages` or `src/content/projects` and they will automatically show up in the application.